### PR TITLE
generate file with `.mp3` extension and not `.wav`

### DIFF
--- a/ai_podcaster.py
+++ b/ai_podcaster.py
@@ -164,7 +164,7 @@ except RateLimitError:
 
 concat_file.close()
 
-podcast_file = f"podcasts/podcast{podcast_id}.wav"
+podcast_file = f"podcasts/podcast{podcast_id}.mp3"
 
 print("Concatenating audio")
 subprocess.run(f"ffmpeg -f concat -safe 0 -i concat.txt -c copy {podcast_file}", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
It turns our that `ffmpeg` generates a `.mp3` file and not a `.wav` file. Therefore, we should generated a file with the appropriate file extension.