### PR TITLE
updates for updated chat gpt library on macOS Ventura

### DIFF
--- a/ai_podcaster.py
+++ b/ai_podcaster.py
@@ -9,8 +9,8 @@ import json
 import sys
 import os
 
-openai.api_key = os.getenv("OPENAI_API_KEY")
 elevenlabs_key = os.getenv("ELEVENLABS_API_KEY")
+# OpenAI imports environment variable OPENAI_API_KEY by default
 
 if elevenlabs_key:
     set_api_key(elevenlabs_key)

--- a/ai_podcaster.py
+++ b/ai_podcaster.py
@@ -90,7 +90,7 @@ def generate_dialog(number_of_dialogs):
     dialogs = []
 
     for _ in range(0, number_of_dialogs):
-        response = openai.ChatCompletion.create(
+        response = openai.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=messages,
             functions=[

--- a/ai_podcaster.py
+++ b/ai_podcaster.py
@@ -83,7 +83,7 @@ messages = [
 
 podcast_id = f"{time.time()}"
 
-def generate_dialog(number_of_dialogs):
+def generate_dialog(number_of_dialogs, debug=False):
     transcript_file_name = f"podcasts/podcast{podcast_id}.txt"
     transcript_file = open(transcript_file_name, "w")
 
@@ -123,12 +123,18 @@ def generate_dialog(number_of_dialogs):
             }
         )
 
-        message = response["choices"][0]["message"] # type: ignore
+        message = response.choices[0].message # type: ignore
+
+        if debug:
+            print(f"response: {response}")
+            print(f"usage: {dict(response).get('usage')}\n")
+            print(f"dump_json: {response.model_dump_json(indent=2)}\n")
+            print(f"message: {message}\n")
 
         messages.append(message)
 
-        function_call = message["function_call"]
-        arguments = json.loads(function_call["arguments"])
+        function_call = message.function_call
+        arguments = json.loads(function_call.arguments)
 
         transcript_file.write(arguments['speaker'] + " says: " + arguments['content'] + "\n")
 


### PR DESCRIPTION
I had to make a few changes to the code for it to execute without errors with the current version of the OpenAI library.

As I state in my commits, we don't have to fetch the `OPENAI_API_KEY` from the environment because it is fetched by default.

The response object is now of type `pydantic` model, so we have to use `.` notation instead of subscripting.

And the call to create the chat changed ever so slightly.