### PR TITLE
Added 60dB integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # AI-Podcaster
 
-Create podcasts about any subject using ChatGPT and ElevenLabs.
+Create podcasts about any subject using ChatGPT and your choice of text-to-speech provider: **ElevenLabs** or **60dB**.
+
+## Requirements
+
+- Python 3
+- [`ffmpeg`](https://ffmpeg.org/) on your `PATH` (used to stitch the audio clips together)
+- Python packages: `pip install -r requirements.txt`
 
 ## Quick Start
 
@@ -14,11 +20,44 @@ You can run the script without command line arguments and it will ask you to inp
 
 ## API Keys
 
-You need to put your OpenAI API key and ElevenLabs API key into the environment variables `OPENAI_API_KEY` and `ELEVENLABS_API_KEY`:
+You always need an OpenAI API key (used to write the script), plus a key for whichever
+text-to-speech provider you want to use:
 
 ```shell
 $ export OPENAI_API_KEY=YOUR_OPENAI_API_KEY
+
+# Use one (or both):
 $ export ELEVENLABS_API_KEY=YOUR_ELEVENLABS_API_KEY
+$ export SIXTYDB_API_KEY=YOUR_60DB_API_KEY
 ```
+
+## Choosing the TTS provider
+
+Set `TTS_PROVIDER` to either `elevenlabs` or `60db`:
+
+```shell
+$ export TTS_PROVIDER=60db        # or: elevenlabs
+```
+
+If `TTS_PROVIDER` is unset, the provider is auto-detected from whichever key is
+present (60dB is preferred if `SIXTYDB_API_KEY` is set).
+
+- **ElevenLabs** uses its built-in preset voices, picked randomly by speaker gender.
+- **60dB** uses the voices on your account (`GET /myvoices`), also picked by gender.
+  Make sure you have at least one male and one female voice for best results.
+
+Both providers share the same pipeline, so output is consistent regardless of choice.
+
+## How it works
+
+1. **ChatGPT** (`gpt-3.5-turbo`) writes the podcast script turn by turn, returning each
+   line as structured `{speaker, gender, content}` data via function calling.
+2. The selected **TTS provider** speaks each line. Every speaker keeps the same voice for
+   the whole episode (voices are assigned by gender and cached per speaker):
+   - **ElevenLabs** &rarr; legacy SDK, `eleven_monolingual_v1` model, built-in preset voices.
+   - **60dB** &rarr; `POST https://api.60db.ai/tts-synthesize` (Bearer auth), voices loaded
+     from `GET https://api.60db.ai/myvoices`, audio returned as base64 and decoded to MP3.
+3. **ffmpeg** concatenates the per-line clips into a single MP3 in `podcasts/`, alongside
+   the plain-text transcript.
 
 Enjoy! (and [buy me a coffee](https://buymeacoffee.com/unconv))

--- a/ai_podcaster.py
+++ b/ai_podcaster.py
@@ -1,21 +1,190 @@
 #!/usr/bin/env python3
 
-from elevenlabs import generate, set_api_key, save, RateLimitError
 import subprocess
 import random
+import base64
 import openai
+import requests
 import time
 import json
 import sys
 import os
 
-elevenlabs_key = os.getenv("ELEVENLABS_API_KEY")
-# OpenAI imports environment variable OPENAI_API_KEY by default
+# ---------------------------------------------------------------------------
+# TTS providers
+#
+# Two backends are supported behind a common interface so the rest of the
+# pipeline (transcript generation, ffmpeg concat, cleanup) is identical no
+# matter which one is used:
+#
+#   provider.name                      -> human readable label
+#   provider.pick_voice(speaker, gender) -> a voice id/name, cached + unique per speaker
+#   provider.synthesize(text, voice)   -> raw audio bytes (mp3)
+#
+# Select with the TTS_PROVIDER env var ("elevenlabs" or "60db"). If unset, the
+# provider is auto-detected from whichever API key is present.
+# ---------------------------------------------------------------------------
 
-if elevenlabs_key:
-    set_api_key(elevenlabs_key)
+
+class TTSRateLimitError(Exception):
+    """Raised by a provider when the backend reports a rate limit."""
+
+
+class ElevenLabsProvider:
+    name = "ElevenLabs"
+
+    # ElevenLabs' built-in preset voices, grouped by gender.
+    VOICE_NAMES = {
+        "male": [
+            "Adam",
+            "Antoni",
+            "Arnold",
+            "Callum",
+            "Charlie",
+            "Clyde",
+            "Daniel",
+            "Ethan",
+        ],
+        "female": [
+            "Bella",
+            "Charlotte",
+            "Domi",
+            "Dorothy",
+            "Elli",
+            "Emily",
+            "Gigi",
+            "Grace",
+        ],
+    }
+
+    def __init__(self, api_key):
+        # Imported lazily so the script still runs with only 60dB configured.
+        from elevenlabs import generate, set_api_key, RateLimitError
+
+        set_api_key(api_key)
+        self._generate = generate
+        self._RateLimitError = RateLimitError
+
+        self._pools = {g: list(v) for g, v in self.VOICE_NAMES.items()}
+        self._assigned = {}
+
+    def pick_voice(self, speaker, gender):
+        if speaker not in self._assigned:
+            pool = self._pools.get(gender, [])
+            choice = random.choice(pool)
+            pool.remove(choice)
+            self._assigned[speaker] = choice
+        return self._assigned[speaker]
+
+    def synthesize(self, text, voice):
+        try:
+            return self._generate(
+                text=text,
+                voice=voice,
+                model="eleven_monolingual_v1",
+            )
+        except self._RateLimitError:
+            raise TTSRateLimitError("ElevenLabs ratelimit exceeded!")
+
+
+class SixtyDBProvider:
+    name = "60dB"
+    BASE_URL = "https://api.60db.ai"
+
+    def __init__(self, api_key):
+        self._headers = {"Authorization": f"Bearer {api_key}"}
+        self._pools = self._load_voice_pools()
+        # Keep the full lists so we can reuse a voice if a gender's pool runs
+        # out (60dB accounts often have only a couple of voices).
+        self._all = {g: list(v) for g, v in self._pools.items()}
+        self._assigned = {}
+
+    def _load_voice_pools(self):
+        resp = requests.get(f"{self.BASE_URL}/myvoices", headers=self._headers, timeout=30)
+        resp.raise_for_status()
+        data = resp.json().get("data", [])
+
+        pools = {"male": [], "female": []}
+        for voice in data:
+            gender = (voice.get("labels") or {}).get("gender", "").lower()
+            if gender in pools and voice.get("voice_id"):
+                pools[gender].append(voice["voice_id"])
+
+        if not pools["male"] and not pools["female"]:
+            sys.exit(
+                "ERROR: No 60dB voices found on your account. "
+                "Create or clone voices, then check GET /myvoices."
+            )
+        return pools
+
+    def pick_voice(self, speaker, gender):
+        if speaker not in self._assigned:
+            pool = self._pools.get(gender, [])
+            fallback = self._all.get(gender, [])
+            if pool:
+                # Prefer a fresh, unique voice for this speaker.
+                choice = random.choice(pool)
+                pool.remove(choice)
+            elif fallback:
+                # Pool exhausted: reuse an existing voice of this gender.
+                choice = random.choice(fallback)
+            else:
+                sys.exit(f"ERROR: No 60dB voices available for gender '{gender}'.")
+            self._assigned[speaker] = choice
+        return self._assigned[speaker]
+
+    def synthesize(self, text, voice):
+        resp = requests.post(
+            f"{self.BASE_URL}/tts-synthesize",
+            headers={**self._headers, "Content-Type": "application/json"},
+            json={
+                "text": text,
+                "voice_id": voice,
+                "output_format": "mp3",
+            },
+            timeout=120,
+        )
+
+        if resp.status_code == 429:
+            raise TTSRateLimitError("60dB ratelimit exceeded!")
+        resp.raise_for_status()
+
+        body = resp.json()
+        if not body.get("success", True):
+            raise RuntimeError(f"60dB TTS error: {body.get('message')}")
+
+        return base64.b64decode(body["audio_base64"])
+
+
+def make_provider():
+    provider = (os.getenv("TTS_PROVIDER") or "").strip().lower()
+    sixtydb_key = os.getenv("SIXTYDB_API_KEY")
+    elevenlabs_key = os.getenv("ELEVENLABS_API_KEY")
+
+    # Auto-detect from whichever key is present when TTS_PROVIDER is unset.
+    if not provider:
+        provider = "60db" if sixtydb_key else "elevenlabs"
+
+    if provider in ("60db", "sixtydb", "60", "sixty"):
+        if not sixtydb_key:
+            sys.exit("ERROR: TTS_PROVIDER=60db but SIXTYDB_API_KEY is not set.")
+        return SixtyDBProvider(sixtydb_key)
+
+    if provider in ("elevenlabs", "eleven", "11labs", "el"):
+        if not elevenlabs_key:
+            sys.exit("ERROR: TTS_PROVIDER=elevenlabs but ELEVENLABS_API_KEY is not set.")
+        return ElevenLabsProvider(elevenlabs_key)
+
+    sys.exit(f"ERROR: Unknown TTS_PROVIDER '{provider}'. Use 'elevenlabs' or '60db'.")
+
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
 
 print("## AI-Podcaster by Unconventional Coding ##\n")
+
+# OpenAI imports environment variable OPENAI_API_KEY by default
 
 if len(sys.argv) > 1:
     with open(sys.argv[1]) as f:
@@ -34,37 +203,6 @@ if not os.path.exists("dialogs"):
 
 if not os.path.exists("podcasts"):
     os.mkdir("podcasts")
-
-voice_names = {
-    "male": [
-        "Adam",
-        "Antoni",
-        "Arnold",
-        "Callum",
-        "Charlie",
-        "Clyde",
-        "Daniel",
-        "Ethan",
-    ],
-    "female": [
-        "Bella",
-        "Charlotte",
-        "Domi",
-        "Dorothy",
-        "Elli",
-        "Emily",
-        "Gigi",
-        "Grace",
-    ]
-}
-
-voices = {}
-
-def get_voice(name, gender):
-    if name not in voices:
-        voices[name] = random.choice(voice_names[gender])
-        voice_names[gender].remove(voices[name])
-    return voices[name]
 
 messages = [
     {
@@ -147,22 +285,22 @@ print("Generating transcript")
 
 dialogs, transcript_file_name = generate_dialog(dialog_count)
 
-print("Generating audio")
+provider = make_provider()
+
+print(f"Generating audio with {provider.name}")
 try:
     for i, dialog in enumerate(dialogs):
-        audio = generate(
-            text=dialog["content"],
-            voice=get_voice(dialog["speaker"], dialog["gender"].lower()),
-            model="eleven_monolingual_v1"
-        )
+        voice = provider.pick_voice(dialog["speaker"], dialog["gender"].lower())
+        audio = provider.synthesize(dialog["content"], voice)
 
-        filename = f"dialogs/dialog{i}.wav"
+        filename = f"dialogs/dialog{i}.mp3"
         concat_file.write("file " + filename + "\n")
         dialog_files.append(filename)
 
-        save(audio, filename) # type: ignore
-except RateLimitError:
-    print("ERROR: ElevenLabs ratelimit exceeded!")
+        with open(filename, "wb") as audio_file:
+            audio_file.write(audio)
+except TTSRateLimitError as error:
+    print(f"ERROR: {error}")
 
 concat_file.close()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 openai
 elevenlabs
+requests


### PR DESCRIPTION
Added 60dB as a second TTS provider alongside ElevenLabs, behind one shared interface so podcasts render the same either way.

  - ai_podcaster.py — SixtyDBProvider (loads voices from /myvoices by gender, synthesizes via /tts-synthesize, decodes base64→MP3,
  handles rate limits); kept ElevenLabsProvider as-is but lazy-imported; make_provider() picks the backend from the TTS_PROVIDER env
  var (auto-detects if unset). Clips now save as .mp3.
  - requirements.txt — added requests.
  - README.md — documented SIXTYDB_API_KEY, the TTS_PROVIDER switch, ffmpeg/install requirements, and a "How it works" section.     

  Switch providers with export TTS_PROVIDER=60db (or elevenlabs).
